### PR TITLE
Fixes urls in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # GroupExpectations
-This repo holds the group expectation document for [wenegrat.github.io](wenegrat.github.io)
+This repo holds the group expectation document for [wenegrat.github.io](https://wenegrat.github.io/)
 
 The file `WenegratGroupExpectations.tex` contains all the content of the document. The other
 documents are simply auxiliary LaTeX files needed to perform the compilation and generate the PDF document
-`WenegratGroupExpectations.pdf` which will finally go on the [group website](wenegrat.github.io).
+`WenegratGroupExpectations.pdf` which will finally go on the [group website](https://wenegrat.github.io/).
 
 Simply submitting change to the `.tex` file does not generate an updated PDF. That has to be done
 locally. Some instructions on how to compile a `LaTeX` document can be found [here](https://www.overleaf.com/learn/latex/Choosing_a_LaTeX_Compiler#LaTeX_editors).


### PR DESCRIPTION
Apparently the URLs in the README are broken! Sorry!

This should correct them